### PR TITLE
fix AttributeError caused by pkg.description being None

### DIFF
--- a/pkgbuilder/utils.py
+++ b/pkgbuilder/utils.py
@@ -98,7 +98,7 @@ def print_package_search(pkg, cachemode=False, prefix='', prefixp=''):
 
     category = pkg.repo
 
-    descl = textwrap.wrap(pkg.description, termwidth - len(prefixp2))
+    descl = textwrap.wrap(pkg.description or '', termwidth - len(prefixp2))
 
     desc = []
     for i in descl:


### PR DESCRIPTION
Seems like some packages don't have an description.

E.g.

    pkgbuilder -Ss python
    Traceback (most recent call last):
    File "/usr/bin/pkgbuilder", line 9, in <module>
        load_entry_point('pkgbuilder==4.2.0', 'console_scripts', 'pkgbuilder')()
    File "/usr/lib/python3.4/site-packages/pkgbuilder/__main__.py", line 246, in main
        pkg, True) + '\n'
    File "/usr/lib/python3.4/site-packages/pkgbuilder/utils.py", line 101, in print_package_search
        descl = textwrap.wrap(pkg.description, termwidth - len(prefixp2))
    File "/usr/lib/python3.4/textwrap.py", line 365, in wrap
        return w.wrap(text)
    File "/usr/lib/python3.4/textwrap.py", line 337, in wrap
        chunks = self._split_chunks(text)
    File "/usr/lib/python3.4/textwrap.py", line 323, in _split_chunks
        text = self._munge_whitespace(text)
    File "/usr/lib/python3.4/textwrap.py", line 140, in _munge_whitespace
        text = text.expandtabs(self.tabsize)
    AttributeError: 'NoneType' object has no attribute 'expandtabs'

Maybe it would be better to set the description to an empty string wherever the pkg is being created. 