### PR TITLE
paccommand option in ini-file

### DIFF
--- a/pkgbuilder/data/pkgbuilder.ini.skel
+++ b/pkgbuilder/data/pkgbuilder.ini.skel
@@ -23,3 +23,4 @@ verbosepkglists=true
 ; overrides -S, useful if /tmp is small
 ; (default: empty/unused)
 chdir=
+paccommand=pacman

--- a/pkgbuilder/pbds.py
+++ b/pkgbuilder/pbds.py
@@ -115,8 +115,6 @@ class PBDS(object):
     log = logging.getLogger('pkgbuilder')
     log.info('*** PKGBUILDer v' + __version__)
 
-
-
     def get_setting(self, name, config_section, config_option,
                     positive, negative):
         """Get the value of a setting, based on config file and arguments.

--- a/pkgbuilder/pbds.py
+++ b/pkgbuilder/pbds.py
@@ -62,11 +62,6 @@ class PBDS(object):
     console = None
     _pyc = None
 
-    if os.getenv('PACMAN') is None:
-        paccommand = 'pacman'
-    else:
-        paccommand = os.getenv('PACMAN')
-
     hassudo = os.path.exists('/usr/bin/sudo')
 
     uid = os.geteuid()
@@ -100,6 +95,11 @@ class PBDS(object):
         'pkgbuilder', 'data/pkgbuilder.ini.skel').decode('utf-8'))
     config.read([confpath], encoding='utf-8')
 
+    if os.getenv('PACMAN') is None:
+        paccommand = config.get('extras', 'paccommand', fallback='pacman')
+    else:
+        paccommand = os.getenv('PACMAN')
+
     # Language changing
     language = config.get('PKGBUILDer', 'language')
     if language != 'auto':
@@ -114,6 +114,8 @@ class PBDS(object):
                         level=logging.DEBUG)
     log = logging.getLogger('pkgbuilder')
     log.info('*** PKGBUILDer v' + __version__)
+
+
 
     def get_setting(self, name, config_section, config_option,
                     positive, negative):


### PR DESCRIPTION
Added the possibility to define a custom pacman command in the config file. If the option is not defined pacman is used as a fallback value. If the PACMAN environment variable is defined the config file option will be ignored.